### PR TITLE
Feature/object properties

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,10 +9,28 @@ pub mod technology;
 
 use dbus;
 
+use std::borrow::Cow;
+
 #[derive(Debug, Fail)]
 pub enum Error {
     #[fail(display = "{}", _0)]
     DbusError(#[cause] dbus::Error),
+    #[fail(display = "'{}'", _0)]
+    PropertyError(#[cause] PropertyError),
+}
+
+#[derive(Debug, Fail)]
+pub enum PropertyError {
+    #[fail(display = "Property not present: '{}'", _0)]
+    NotPresent(Cow<'static, str>),
+    #[fail(display = "Failed to cast property: '{}'", _0)]
+    Cast(Cow<'static, str>)
+}
+
+impl From<PropertyError> for Error {
+    fn from(e: PropertyError) -> Self {
+        Error::PropertyError(e)
+    }
 }
 
 impl From<dbus::Error> for Error {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,8 +8,11 @@ pub mod service;
 pub mod technology;
 
 use dbus;
+use dbus::arg::{cast, RefArg, Variant};
 
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::str::FromStr;
 
 #[derive(Debug, Fail)]
 pub enum Error {
@@ -37,4 +40,30 @@ impl From<dbus::Error> for Error {
     fn from(e: dbus::Error) -> Self {
         Error::DbusError(e)
     }
+}
+
+/// Convenience function for getting property values.
+fn get_property<T: Clone + 'static>(
+    properties: HashMap<String, Variant<Box<RefArg + 'static>>>,
+    prop_name: &'static str,
+) -> Result<T, Error> {
+    properties.get(prop_name)
+        .ok_or(PropertyError::NotPresent(Cow::Borrowed(prop_name)).into())
+        .and_then(|variant|
+            cast::<T>(&variant.0).cloned()
+                .ok_or(PropertyError::Cast(Cow::Borrowed(prop_name)).into())
+        )
+}
+
+/// Convenience function for getting property values that impl `FromStr`.
+fn get_property_fromstr<T: FromStr + 'static>(
+    properties: HashMap<String, Variant<Box<RefArg + 'static>>>,
+    prop_name: &'static str,
+) -> Result<T, Error> {
+    properties.get(prop_name)
+        .ok_or(PropertyError::NotPresent(Cow::Borrowed(prop_name)).into())
+        .and_then(|variant| variant.as_str()
+            .and_then(|s| T::from_str(s).ok())
+            .ok_or(PropertyError::Cast(Cow::Borrowed(prop_name)).into())
+        )
 }


### PR DESCRIPTION
Adds a `PropertyError` variant to `api::Error` so that `get_` property functions don't need to wrap in `Option<T>` for the function signature. `Manager::get_state` is modified to take advantage of this, and `get_`/`set_offline_mode` is also added for `Manager`.

Property functions for `Technology` and `Service` could technically also get populated, but the `GetProperties` dbus method for both is marked `deprecated`, so that's TBD for now.