### PR TITLE
ci: add travisci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: rust
+dist: xenial
+sudo: required
+
+rust:
+  - stable
+
+before_install:
+  - sudo apt-get update
+  - ci/connman.sh prep
+  - ci/connman.sh build
+  - ci/wpa_supplicant.sh prep
+  - ci/wpa_supplicant.sh build
+  - ci/hostapd.sh prep
+  - ci/hostapd.sh build
+
+before_script:
+  - ci/wpa_supplicant.sh run
+  - ci/connman.sh run
+  - sudo ifconfig wlan1 up
+  - ci/hostapd.sh run
+  - sleep 5
+  - sudo iw dev wlan0 scan || echo "wlan0 busy, keep going"
+  - sudo connmanctl services
+
+script:
+  - cargo test
+  - source $HOME/.cargo/env && cargo build --example wifi_scan_list
+  - source $HOME/.cargo/env && cargo build --features=introspection --example wifi_introspect
+  - sudo target/debug/examples/wifi_introspect
+  - sudo target/debug/examples/wifi_scan_list
+

--- a/ci/connman.conf
+++ b/ci/connman.conf
@@ -1,0 +1,2 @@
+[General]
+NetworkInterfaceBlacklist=vmnet,vboxnet,virbr,ifb,docker,veth,eth,ens,wlan1

--- a/ci/connman.sh
+++ b/ci/connman.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -x
+
+CONNMAN_SRC_PATH="./connman"
+
+do_action_prep() {
+    sudo apt install \
+        linux-modules-extra-`uname -r` \
+        dbus \
+        libdbus-1-dev \
+        gnutls-dev \
+        gnutls-bin \
+        xtables-addons-common \
+        xtables-addons-source \
+        rfkill
+
+    # TODO: Install deps to be able to run stock `bootstrap-config`
+    #sudo apt install openconnect
+    #sudo apt install openvpn
+    #sudo apt install nftables
+    #sudo apt install libnftnl-dev
+    #sudo apt install vpnc
+
+    sudo modprobe mac80211_hwsim radios=2 fake_hw_scan=1
+
+    sudo rfkill unblock all
+
+    iw reg set US
+
+    # STA
+    sudo ifconfig wlan0 up 192.168.1.2
+
+    # AP (used by hostapd)
+    sudo ifconfig wlan1 up 192.168.1.1
+
+    git clone --depth 1 -b 1.36 \
+        https://git.kernel.org/pub/scm/network/connman/connman.git \
+        ${CONNMAN_SRC_PATH}
+}
+
+do_action_build() {
+    cd ${CONNMAN_SRC_PATH}
+    ./bootstrap
+    ./configure
+    make
+    sudo make install
+    cd ..
+
+    # This may be done automatically if using `bootstrap-config`
+    sudo cp connman/src/connman-dbus.conf /etc/dbus-1/system.d/
+    sudo systemctl reload dbus
+}
+
+do_action_run() {
+    sudo connmand -d --nodnsproxy -i wlan0
+
+    # Make sure wifi is enabled
+    sudo connmanctl enable wifi
+
+    sudo ifconfig wlan0 down
+    sudo ifconfig wlan0 up
+}
+
+action="$1"
+shift
+args="$@"
+case $action in
+    prep)
+        do_action_prep
+        ;;
+    build)
+        do_action_build
+        ;;
+    run)
+        do_action_run
+        ;;
+    *)
+        >&2 echo Unknown action $action
+        exit 1
+        ;;
+esac

--- a/ci/hostapd.conf
+++ b/ci/hostapd.conf
@@ -1,0 +1,25 @@
+country_code=US
+
+interface=wlan1
+driver=nl80211
+logger_stdout=-1
+logger_stdout_level=2
+ctrl_interface_group=0
+ctrl_interface=/var/run/hostapd
+
+# WPA2-AES encryption
+ssid=myssid
+auth_algs=1
+wpa=2
+wpa_key_mgmt=WPA-PSK
+wpa_pairwise=CCMP
+wpa_passphrase=mypassword
+
+# IEEE 802.11g
+hw_mode=g
+# Setting channel 1 force hostapd not to use ACS algo.
+channel=6
+
+# IEEE 802.11n
+#ieee80211n=1
+#TODO: uncomment once i compile into 2.7

--- a/ci/hostapd.sh
+++ b/ci/hostapd.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -x
+
+HOSTAP_SRC_PATH="./hostap"
+
+do_action_prep() {
+    sudo apt install hostapd
+}
+
+do_action_build() {
+    cd ${HOSTAP_SRC_PATH}/hostapd
+    cp defconfig .config
+    make clean
+    make
+    sudo make install
+    cd ../..
+}
+
+do_action_run() {
+    sudo /usr/local/bin/hostapd -B -ddt ci/hostapd.conf
+}
+
+action="$1"
+shift
+args="$@"
+case $action in
+    prep)
+        do_action_prep
+        ;;
+    build)
+        do_action_build
+        ;;
+    run)
+        do_action_run
+        ;;
+    *)
+        >&2 echo Unknown action $action
+        exit 1
+        ;;
+esac

--- a/ci/wpa_supplicant.conf
+++ b/ci/wpa_supplicant.conf
@@ -1,0 +1,4 @@
+country=US
+ctrl_interface=/var/run/wpa_supplicant
+update_config=1
+bss_expiration_age=3600

--- a/ci/wpa_supplicant.sh
+++ b/ci/wpa_supplicant.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -x
+
+HOSTAP_SRC_PATH="./hostap"
+
+do_action_prep() {
+    sudo apt install \
+        libnl-3-dev \
+        libnl-genl-3-dev
+
+    sudo apt install wpasupplicant
+
+    git clone --depth 1 -b hostap_2_7 \
+        git://w1.fi/hostap.git \
+        ${HOSTAP_SRC_PATH}
+}
+
+do_action_build() {
+    cd ${HOSTAP_SRC_PATH}/wpa_supplicant
+    cp defconfig .config
+    # Enable dbus
+    cat >> .config << "EOF"
+CONFIG_CTRL_IFACE_DBUS=y
+CONFIG_CTRL_IFACE_DBUS_NEW=y
+CONFIG_CTRL_IFACE_DBUS_INTRO=y
+EOF
+
+    make
+    sudo make install
+    cd ../..
+}
+
+do_action_run() {
+    sudo /usr/local/sbin/wpa_supplicant -B -dd -Dnl80211 -u -iwlan0 -c ci/wpa_supplicant.conf
+}
+
+action="$1"
+shift
+args="$@"
+case $action in
+    prep)
+        do_action_prep
+        ;;
+    build)
+        do_action_build
+        ;;
+    run)
+        do_action_run
+        ;;
+    *)
+        >&2 echo Unknown action $action
+        exit 1
+        ;;
+esac

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,13 @@
 //! extern crate connman;
 //! extern crate dbus;
 //! extern crate dbus_tokio;
+//! extern crate futures;
 //! extern crate tokio;
 //!
 //! use connman::Manager;
 //! use dbus::{BusType, Connection};
 //! use dbus_tokio::AConnection;
+//! use futures::Future;
 //! use tokio::reactor::Handle;
 //! use tokio::runtime::current_thread::Runtime;
 //!


### PR DESCRIPTION
Sets up a `mac80211_hwsim`-based network for testing on a running
instance of `connmand`.

Also fixes readme example for test.