### PR TITLE
Parsed properties for Technology and Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Added
+- Introspection functionality via `introspect` feature
+- Property functions for Manager
+- Parsed properties for Technology and Service
+
 ## [0.1.1]
 
 ### Added

--- a/examples/wifi_introspect.rs
+++ b/examples/wifi_introspect.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use connman::api::Error as ConnmanError;
 use connman::{Manager, Technology};
-use dbus::arg::RefArg;
+use connman::api::technology::Type as TechnologyType;
 use dbus::{BusType, Connection};
 use dbus_tokio::AConnection;
 use futures::Future;
@@ -23,7 +23,7 @@ pub fn get_technology_wifi(
         .get_technologies()
         .map(|v| {
             v.into_iter().find(move |t| {
-                t.args.get("Type").and_then(|variant| variant.as_str()) == Some("wifi")
+                t.props.type_ == TechnologyType::Wifi
             })
         })
 }

--- a/examples/wifi_scan_list.rs
+++ b/examples/wifi_scan_list.rs
@@ -7,7 +7,6 @@ use std::rc::Rc;
 
 use connman::api::Error as ConnmanError;
 use connman::{Manager, Technology};
-use dbus::arg::RefArg;
 use dbus::{BusType, Connection};
 use dbus_tokio::AConnection;
 use futures::Future;
@@ -22,7 +21,7 @@ pub fn get_technology_wifi(
         // Filter out the wifi technology (eventually this will be a simple library call)
         .map(|v| {
             v.into_iter().find(move |t| {
-                t.args.get("Type").and_then(|variant| variant.as_str()) == Some("wifi")
+                t.props.type_ == connman::api::technology::Type::Wifi
             })
         })
 }

--- a/src/api/manager.rs
+++ b/src/api/manager.rs
@@ -7,7 +7,7 @@ use futures::Future;
 use xml::reader::EventReader;
 
 use super::gen::manager::Manager as IManager;
-use super::service::Service;
+use super::service::{Service, Properties as ServiceProperties};
 use super::technology::Technology;
 use super::Error;
 use std::str::FromStr;
@@ -60,7 +60,9 @@ impl Manager {
             .map_err(Error::from)
             .map(move |v|
                 v.into_iter()
-                    .map(|(path, args)| Service::new(connclone.clone(), path, args))
+                    .filter_map(|(path, args)| {
+                        Service::new(connclone.clone(), path, args).ok()
+                    })
                     .collect()
             )
     }

--- a/src/api/manager.rs
+++ b/src/api/manager.rs
@@ -46,7 +46,9 @@ impl Manager {
             .map_err(Error::from)
             .map(move |v|
                 v.into_iter()
-                    .map(|(path, args)| Technology::new(connclone.clone(), path, args))
+                    .filter_map(|(path, args)| {
+                        Technology::new(connclone.clone(), path, args).ok()
+                    })
                     .collect()
             )
     }

--- a/src/api/manager.rs
+++ b/src/api/manager.rs
@@ -16,14 +16,14 @@ use std::rc::Rc;
 /// Futures-aware wrapper struct for connman Manager object.
 #[derive(Clone, Debug)]
 pub struct Manager {
-    connection: Rc<AConnection>,
+    connpath: ConnPath<'static, Rc<AConnection>>,
     // TODO: Signal subscription/dispatcher
 }
 
 impl Manager {
     pub fn new(connection: Rc<AConnection>) -> Self {
         Manager {
-            connection
+            connpath: Self::connpath(connection),
         }
     }
 
@@ -40,11 +40,10 @@ impl Manager {
 
 impl Manager {
     pub fn get_technologies(&self) -> impl Future<Item=Vec<Technology>, Error=Error> {
-        let connclone = self.connection.clone();
+        let connclone = self.connpath.conn.clone();
 
-        let connpath = Self::connpath(connclone.clone());
-        IManager::get_technologies(&connpath)
-            .map_err(|e| e.into())
+        IManager::get_technologies(&self.connpath)
+            .map_err(Error::from)
             .map(move |v|
                 v.into_iter()
                     .map(|(path, args)| Technology::new(connclone.clone(), path, args))
@@ -53,11 +52,10 @@ impl Manager {
     }
 
     pub fn get_services(&self) -> impl Future<Item=Vec<Service>, Error=Error> {
-        let connclone = self.connection.clone();
+        let connclone = self.connpath.conn.clone();
 
-        let connpath = Self::connpath(connclone.clone());
-        IManager::get_services(&connpath)
-            .map_err(|e| e.into())
+        IManager::get_services(&self.connpath)
+            .map_err(Error::from)
             .map(move |v|
                 v.into_iter()
                     .map(|(path, args)| Service::new(connclone.clone(), path, args))
@@ -71,8 +69,8 @@ impl Manager {
     pub fn introspect(&self) -> impl Future<Item=EventReader<std::io::Cursor<Vec<u8>>>, Error=Error> {
         use crate::api::gen::manager::OrgFreedesktopDBusIntrospectable as Introspectable;
 
-        Introspectable::introspect(&Self::connpath(self.connection.clone()))
-            .map_err(|e| e.into())
+        Introspectable::introspect(&self.connpath)
+            .map_err(Error::from)
             .map(|s| {
                 let rdr = std::io::Cursor::new(s.into_bytes());
                 EventReader::new(rdr)
@@ -80,27 +78,26 @@ impl Manager {
     }
 
     pub fn get_state(&self) -> impl Future<Item=State, Error=Error> {
-        let connpath = Self::connpath(self.connection.clone());
-        IManager::get_properties(&connpath)
-            .map_err(|e| e.into())
+        IManager::get_properties(&self.connpath)
+            .map_err(Error::from)
             .and_then(move |a|
                 super::get_property_fromstr::<State>(&a, "State")
+                    .map_err(Error::from)
             )
     }
 
     pub fn get_offline_mode(&self) -> impl Future<Item=bool, Error=Error> {
-        let connpath = Self::connpath(self.connection.clone());
-        IManager::get_properties(&connpath)
-            .map_err(|e| e.into())
+        IManager::get_properties(&self.connpath)
+            .map_err(Error::from)
             .and_then(move |a|
                 super::get_property::<bool>(&a, "OfflineMode")
+                    .map_err(Error::from)
             )
     }
 
     pub fn set_offline_mode(&self, offline_mode: bool) -> impl Future<Item=(), Error=Error> {
-        let connpath = Self::connpath(self.connection.clone());
-        IManager::set_property(&connpath, "OfflineMode", Variant(offline_mode))
-            .map_err(|e| e.into())
+        IManager::set_property(&self.connpath, "OfflineMode", Variant(offline_mode))
+            .map_err(Error::from)
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,6 +15,8 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 type RefArgMap = HashMap<String, Variant<Box<RefArg + 'static>>>;
+type RefArgMapRef<'a> = HashMap<String, &'a RefArg>;
+type RefArgIter<'a> = Box<Iterator<Item=&'a RefArg> + 'a>;
 
 #[derive(Debug, Fail)]
 pub enum Error {
@@ -68,4 +70,55 @@ fn get_property_fromstr<T: FromStr + 'static>(
             .and_then(|s| T::from_str(s).ok())
             .ok_or_else(|| PropertyError::Cast(Cow::Borrowed(prop_name)))
         )
+}
+
+/// Convenience function for getting property values from a Dict or Array.
+fn get_property_argiter<'a>(
+    properties: &'a RefArgMap,
+    prop_name: &'static str,
+) -> Result<RefArgIter<'a>, PropertyError> {
+    properties.get(prop_name)
+        .ok_or_else(|| PropertyError::NotPresent(Cow::Borrowed(prop_name)))
+        .and_then(|variant|
+            variant.0.as_iter()
+                .ok_or_else(|| PropertyError::Cast(Cow::Borrowed(prop_name)))
+        )
+}
+
+pub trait FromProperties: Sized {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError>;
+}
+
+impl FromProperties for String {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        get_property_fromstr::<Self>(properties, prop_name)
+    }
+}
+
+impl <T: FromProperties + Clone + 'static> FromProperties for Vec<T> {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        get_property::<Vec<T>>(properties, prop_name)
+    }
+}
+
+impl FromProperties for u8 {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        get_property::<Self>(properties, prop_name)
+    }
+}
+
+impl FromProperties for bool {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        get_property::<Self>(properties, prop_name)
+    }
+}
+
+impl <T: FromProperties> FromProperties for Option<T> {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        match T::from_properties(properties, prop_name) {
+            Err(PropertyError::NotPresent(_)) => Ok(None),
+            Ok(s) => Ok(Some(s)),
+            res => res.map(Option::Some),
+        }
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -48,12 +48,12 @@ impl From<dbus::Error> for Error {
 fn get_property<T: Clone + 'static>(
     properties: &RefArgMap,
     prop_name: &'static str,
-) -> Result<T, Error> {
+) -> Result<T, PropertyError> {
     properties.get(prop_name)
-        .ok_or(PropertyError::NotPresent(Cow::Borrowed(prop_name)).into())
+        .ok_or_else(|| PropertyError::NotPresent(Cow::Borrowed(prop_name)))
         .and_then(|variant|
             cast::<T>(&variant.0).cloned()
-                .ok_or(PropertyError::Cast(Cow::Borrowed(prop_name)).into())
+                .ok_or_else(|| PropertyError::Cast(Cow::Borrowed(prop_name)))
         )
 }
 
@@ -61,11 +61,11 @@ fn get_property<T: Clone + 'static>(
 fn get_property_fromstr<T: FromStr + 'static>(
     properties: &RefArgMap,
     prop_name: &'static str,
-) -> Result<T, Error> {
+) -> Result<T, PropertyError> {
     properties.get(prop_name)
-        .ok_or(PropertyError::NotPresent(Cow::Borrowed(prop_name)).into())
+        .ok_or_else(|| PropertyError::NotPresent(Cow::Borrowed(prop_name)))
         .and_then(|variant| variant.as_str()
             .and_then(|s| T::from_str(s).ok())
-            .ok_or(PropertyError::Cast(Cow::Borrowed(prop_name)).into())
+            .ok_or_else(|| PropertyError::Cast(Cow::Borrowed(prop_name)))
         )
 }

--- a/src/api/service.rs
+++ b/src/api/service.rs
@@ -1,82 +1,912 @@
 use dbus::{arg, ConnPath};
 use dbus_tokio::AConnection;
 use futures::Future;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::str::FromStr;
 
 #[cfg(feature = "introspection")]
 use xml::reader::EventReader;
 
 use super::gen::service::Service as IService;
-use super::Error;
+use super::Error as ApiError;
+use super::{FromProperties, PropertyError};
+use crate::api::{RefArgMap, RefArgIter, get_property_argiter};
+use std::convert::TryFrom;
+use dbus::arg::{Variant, RefArg, cast};
 
 /// Futures-aware wrapper struct for connman Service object.
 #[derive(Debug)]
 pub struct Service {
-    connection: Rc<AConnection>,
-    pub path: dbus::Path<'static>,
-    pub args: HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>,
+    connpath: ConnPath<'static, Rc<AConnection>>,
+    properties: Properties,
 }
 
 impl Service {
     pub fn new(
         connection: Rc<AConnection>,
         path: dbus::Path<'static>,
-        args: HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>,
-    ) -> Self {
-        Service {
-            connection,
-            path,
-            args,
-        }
+        args: RefArgMap,
+    ) -> Result<Self, ApiError> {
+        let properties = Properties::try_from(args)
+            .map_err(ApiError::from)?;
+
+        Ok(Service {
+            connpath: Self::connpath(path, connection),
+            properties,
+        })
     }
 
-    pub fn connpath(&self, conn: Rc<AConnection>) -> ConnPath<'static, Rc<AConnection>> {
+    pub fn connpath(path: dbus::Path<'static>, conn: Rc<AConnection>) -> ConnPath<'static, Rc<AConnection>> {
         let connpath = ConnPath {
             conn: conn,
             dest: "net.connman".into(),
-            path: self.path.clone(),
+            path,
             timeout: 5000,
         };
         connpath
+    }
+
+    pub fn path(&self) -> &dbus::Path<'static> {
+        &self.connpath.path
     }
 }
 
 impl Service {
     #[cfg(feature = "introspection")]
-    pub fn introspect(&self) -> impl Future<Item=EventReader<std::io::Cursor<Vec<u8>>>, Error=Error> {
+    pub fn introspect(&self) -> impl Future<Item=EventReader<std::io::Cursor<Vec<u8>>>, Error=ApiError> {
         use crate::api::gen::service::OrgFreedesktopDBusIntrospectable as Introspectable;
 
-        Introspectable::introspect(&self.connpath(self.connection.clone()))
-            .map_err(|e| e.into())
+        Introspectable::introspect(&self.connpath)
+            .map_err(ApiError::from)
             .map(|s| {
                 let rdr = std::io::Cursor::new(s.into_bytes());
                 EventReader::new(rdr)
             })
     }
 
-    pub fn connect(&self) -> impl Future<Item=(), Error=Error> {
-        let connpath = self.connpath(self.connection.clone());
-        IService::connect(&connpath).map_err(|e| e.into())
+    pub fn connect(&self) -> impl Future<Item=(), Error=ApiError> {
+        IService::connect(&self.connpath).map_err(ApiError::from)
     }
 
-    pub fn disconnect(&self) -> impl Future<Item=(), Error=Error> {
-        let connpath = self.connpath(self.connection.clone());
-        IService::disconnect(&connpath).map_err(|e| e.into())
+    pub fn disconnect(&self) -> impl Future<Item=(), Error=ApiError> {
+        IService::disconnect(&self.connpath).map_err(ApiError::from)
     }
 
-    pub fn remove(&self) -> impl Future<Item=(), Error=Error> {
-        let connpath = self.connpath(self.connection.clone());
-        IService::remove(&connpath).map_err(|e| e.into())
+    pub fn remove(&self) -> impl Future<Item=(), Error=ApiError> {
+        IService::remove(&self.connpath).map_err(ApiError::from)
     }
 
-    pub fn move_before(&self, service: &Service) -> impl Future<Item=(), Error=Error> {
-        let connpath = self.connpath(self.connection.clone());
-        IService::move_before(&connpath, service.path.clone()).map_err(|e| e.into())
+    pub fn move_before(&self, service: &Service) -> impl Future<Item=(), Error=ApiError> {
+        IService::move_before(&self.connpath, service.path().clone()).map_err(ApiError::from)
     }
 
-    pub fn move_after(&self, service: &Service) -> impl Future<Item=(), Error=Error> {
-        let connpath = self.connpath(self.connection.clone());
-        IService::move_after(&connpath, service.path.clone()).map_err(|e| e.into())
+    pub fn move_after(&self, service: &Service) -> impl Future<Item=(), Error=ApiError> {
+        IService::move_after(&self.connpath, service.path().clone()).map_err(ApiError::from)
+    }
+}
+
+#[derive(Debug)]
+pub struct Properties {
+    /// Connection state
+    state: State,
+    /// Error reason; only valid for `State::Failure`
+    error: Option<Error>,
+    /// Service name
+    name: Option<String>,
+    /// Service name
+    type_: Option<Type>,
+    /// Service name
+    // TODO: enum variants?
+    security: Option<Vec<String>>,
+    /// Signal strength
+    strength: Option<u8>,
+    /// Set if favorite or User-selected
+    favorite: bool,
+    /// Set if configured externally
+    immutable: bool,
+    /// Whether or not to automatically connect if no other connection
+    autoconnect: bool,
+    /// Set if service is roaming
+    roaming: Option<bool>,
+    /// List of currently-active nameservers
+    nameservers: Vec<String>, // TODO: Deserialize `String` into `IpAddr`?
+    /// List of manually-configured nameservers
+    nameservers_config: Vec<String>, // TODO: Deserialize `String` into `IpAddr`?
+    /// List of currently-active timeservers
+    timeservers: Vec<String>,
+    /// List of manually-configured timeservers
+    timeservers_config: Vec<String>,
+    /// List of currently-used search domains
+    domains: Vec<String>,
+    /// List of manually-configured search domains
+    domains_config: Vec<String>,
+    /// Ipv4 related information
+    ipv4: Ipv4,
+    /// Ipv4 config related information
+    ipv4_config: Ipv4,
+    /// Ipv6 related information
+    ipv6: Ipv6,
+    /// Ipv6 config related information
+    ipv6_config: Ipv6,
+    /// Proxy related information
+    proxy: Proxy,
+    /// Proxy config related information
+    proxy_config: Proxy,
+    /// Provider (VPN) related information
+    provider: Provider,
+    /// Ethernet related information
+    ethernet: Ethernet,
+    /// Whether or not mDNS support is enabled
+    mdns: Option<bool>,
+    /// Whether or not mDNS (config) support is enabled
+    mdns_config: Option<bool>,
+}
+
+impl FromProperties for State {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        super::get_property_fromstr::<Self>(properties, prop_name)
+    }
+}
+
+impl FromProperties for Error {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        super::get_property_fromstr::<Self>(properties, prop_name)
+    }
+}
+
+impl FromProperties for Type {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        super::get_property_fromstr::<Self>(properties, prop_name)
+    }
+}
+impl FromProperties for Ipv4 {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        let mut i = get_property_argiter(properties, prop_name)?;
+        let mut m: HashMap<String, String> = HashMap::new();
+        while let Some(key) = i.next().and_then(|k| k.as_str()) {
+            if let Some(val) = i.next().and_then(|v| v.as_str()) {
+                let _ = m.insert(key.to_string(), val.to_string());
+            }
+        }
+
+        let method = if let Some(method) = m.get(Ipv4Kind::Method.into()) {
+            Some(method.parse::<Ipv4Method>()?)
+        } else { None };
+        let address = m.get(Ipv4Kind::Address.into()).cloned();
+        let netmask = m.get(Ipv4Kind::Netmask.into()).cloned();
+        let gateway = m.get(Ipv4Kind::Gateway.into()).cloned();
+
+        Ok(Ipv4 {
+            method,
+            address,
+            netmask,
+            gateway,
+        })
+    }
+}
+
+impl FromProperties for Ipv6 {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        let mut i = get_property_argiter(properties, prop_name)?;
+        let mut m: HashMap<&str, &str> = HashMap::new();
+        while let Some(key) = i.next().and_then(|k| k.as_str()) {
+            if let Some(val) = i.next().and_then(|v| v.as_str()) {
+                let _ = m.insert(key, val);
+            }
+        }
+
+        let method = m.get(Ipv6Kind::Method.into())
+            .and_then(|method| method.parse::<Ipv6Method>().ok());
+
+        let address = m.get(Ipv6Kind::Address.into()).copied().map(String::from);
+        let prefix_length = m.get(Ipv6Kind::PrefixLength.into())
+            .and_then(|val| val.parse::<u8>().ok());
+
+        let gateway = m.get(Ipv6Kind::Gateway.into()).copied().map(String::from);
+        let privacy = m.get(Ipv6Kind::Privacy.into())
+            .and_then(|privacy| privacy.parse::<Ipv6Privacy>().ok());
+
+        Ok(Ipv6 {
+            method,
+            address,
+            prefix_length,
+            gateway,
+            privacy,
+        })
+    }
+}
+
+impl FromProperties for Proxy {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        let mut i = get_property_argiter(properties, prop_name)?;
+        let mut m: HashMap<&str, &RefArg> = HashMap::new();
+        while let Some(key) = i.next().and_then(|k| k.as_str()) {
+            if let Some(val) = i.next() {
+                let _ = m.insert(key, val);
+            }
+        }
+
+        let method = m.get(ProxyKind::Method.into())
+            .and_then(|refarg| refarg.as_str())
+            .and_then(|s| ProxyMethod::from_str(s).ok());
+
+        let url = m.get(ProxyKind::Url.into())
+            .and_then(|refarg| refarg.as_str())
+            .map(String::from);
+
+        let servers = m.get(ProxyKind::Servers.into())
+            .and_then(|refarg| cast::<Vec<String>>(&refarg.box_clone()).cloned());
+
+        let excludes = m.get(ProxyKind::Excludes.into())
+            .and_then(|refarg| cast::<Vec<String>>(&refarg.box_clone()).cloned());
+
+        Ok(Proxy {
+            method,
+            url,
+            servers,
+            excludes,
+        })
+    }
+}
+
+impl FromProperties for Provider {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        let mut i = get_property_argiter(properties, prop_name)?;
+        let mut m: HashMap<&str, &str> = HashMap::new();
+        while let Some(key) = i.next().and_then(|k| k.as_str()) {
+            if let Some(val) = i.next().and_then(|v| v.as_str()) {
+                let _ = m.insert(key, val);
+            }
+        }
+
+        let host = m.get(ProviderKind::Host.into()).copied().map(String::from);
+        let domain = m.get(ProviderKind::Domain.into()).copied().map(String::from);
+        let name = m.get(ProviderKind::Name.into()).copied().map(String::from);
+        let type_ = m.get(ProviderKind::Type.into()).copied().map(String::from);
+
+        Ok(Provider {
+            host,
+            domain,
+            name,
+            type_,
+        })
+    }
+}
+
+impl FromProperties for Ethernet {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        let mut i = get_property_argiter(properties, prop_name)?;
+        let mut eth = Ethernet {
+            method: None,
+            interface: None,
+            address: None,
+            mtu: None,
+        };
+        while let Some(key) = i.next().and_then(|k| k.as_str()) {
+            let kind = EthernetKind::from_str(key).expect("Unhandled EthernetKind variant");
+            match kind {
+                EthernetKind::Method => {
+                    if let Some(method) = i.next()
+                        .and_then(|v| v.as_str())
+                        .and_then(|v| EthernetMethod::from_str(v).ok()) {
+                            eth.method = Some(method);
+                        };
+                }
+                EthernetKind::Interface => {
+                    if let Some(iface) = i.next()
+                        .and_then(|v| v.as_str()) {
+                            eth.interface = Some(iface.to_string());
+                        };
+                }
+                EthernetKind::Address => {
+                    if let Some(addr) = i.next()
+                        .and_then(|v| v.as_str()) {
+                            eth.address = Some(addr.to_string());
+                        };
+                }
+                EthernetKind::Mtu => {
+                    if let Some(mtu) = i.next()
+                        .and_then(|v| v.as_u64()) {
+                            eth.mtu = Some(mtu as u16);
+                        };
+                }
+            }
+        }
+        Ok(eth)
+    }
+}
+
+impl Properties {
+    pub fn try_from(props: RefArgMap) -> Result<Self, PropertyError> {
+        let state = State::from_properties(&props, PropertyKind::State.into())?;
+
+        let error: Option<Error> = FromProperties::from_properties(&props, PropertyKind::Error.into())?;
+
+        let name: Option<String> = FromProperties::from_properties(&props, PropertyKind::Name.into())?;
+
+        let type_: Option<Type> = FromProperties::from_properties(&props, PropertyKind::Type.into())?;
+
+        let security: Option<Vec<String>> = FromProperties::from_properties(&props, PropertyKind::Security.into())?;
+
+        let strength: Option<u8> = FromProperties::from_properties(&props, PropertyKind::Strength.into())?;
+
+        let favorite = bool::from_properties(&props, PropertyKind::Favorite.into())?;
+        let immutable = bool::from_properties(&props, PropertyKind::Immutable.into())?;
+        let autoconnect = bool::from_properties(&props, PropertyKind::AutoConnect.into())?;
+
+        let roaming: Option<bool> = FromProperties::from_properties(&props, PropertyKind::Roaming.into())?;
+
+        let nameservers: Vec<String> = FromProperties::from_properties(&props, PropertyKind::Nameservers.into())?;
+        let nameservers_config: Vec<String> = FromProperties::from_properties(&props, PropertyKind::NameserversConfiguration.into())?;
+        let timeservers: Vec<String> = FromProperties::from_properties(&props, PropertyKind::Timeservers.into())?;
+        let timeservers_config: Vec<String> = FromProperties::from_properties(&props, PropertyKind::TimeserversConfiguration.into())?;
+        let domains: Vec<String> = FromProperties::from_properties(&props, PropertyKind::Domains.into())?;
+        let domains_config: Vec<String> = FromProperties::from_properties(&props, PropertyKind::DomainsConfiguration.into())?;
+
+        let ipv4 = Ipv4::from_properties(&props, PropertyKind::Ipv4.into())?;
+        let ipv4_config = Ipv4::from_properties(&props, PropertyKind::Ipv4Configuration.into())?;
+        let ipv6 = Ipv6::from_properties(&props, PropertyKind::Ipv6.into())?;
+        let ipv6_config = Ipv6::from_properties(&props, PropertyKind::Ipv6Configuration.into())?;
+
+        let proxy = Proxy::from_properties(&props, PropertyKind::Proxy.into())?;
+        let proxy_config = Proxy::from_properties(&props, PropertyKind::ProxyConfiguration.into())?;
+
+        let provider = Provider::from_properties(&props, PropertyKind::Provider.into())?;
+
+        let ethernet = Ethernet::from_properties(&props, PropertyKind::Ethernet.into())?;
+
+        let mdns: Option<bool> = FromProperties::from_properties(&props, PropertyKind::Mdns.into())?;
+        let mdns_config: Option<bool> = FromProperties::from_properties(&props, PropertyKind::MdnsConfiguration.into())?;
+
+        Ok(Properties {
+            state,
+            error,
+            name,
+            type_,
+            security,
+            strength,
+            favorite,
+            immutable,
+            autoconnect,
+            roaming,
+            nameservers,
+            nameservers_config,
+            timeservers,
+            timeservers_config,
+            domains,
+            domains_config,
+            ipv4,
+            ipv4_config,
+            ipv6,
+            ipv6_config,
+            proxy,
+            proxy_config,
+            provider,
+            ethernet,
+            mdns,
+            mdns_config
+        })
+    }
+}
+
+/// Service property fields.
+enum PropertyKind {
+    State,
+    Error,
+    Name,
+    Type,
+    Security,
+    Strength,
+    Favorite,
+    Immutable,
+    AutoConnect,
+    Roaming,
+    Nameservers,
+    NameserversConfiguration,
+    Timeservers,
+    TimeserversConfiguration,
+    Domains,
+    DomainsConfiguration,
+    Ipv4,
+    Ipv4Configuration,
+    Ipv6,
+    Ipv6Configuration,
+    Proxy,
+    ProxyConfiguration,
+    Provider,
+    Ethernet,
+    Mdns,
+    MdnsConfiguration,
+}
+
+impl From<PropertyKind> for &'static str {
+    fn from(prop: PropertyKind) -> Self {
+        match prop {
+            PropertyKind::State => "State",
+            PropertyKind::Error => "Error",
+            PropertyKind::Name => "Name",
+            PropertyKind::Type => "Type",
+            PropertyKind::Security => "Security",
+            PropertyKind::Strength => "Strength",
+            PropertyKind::Favorite => "Favorite",
+            PropertyKind::Immutable => "Immutable",
+            PropertyKind::AutoConnect => "AutoConnect",
+            PropertyKind::Roaming => "Roaming",
+            PropertyKind::Nameservers => "Nameservers",
+            PropertyKind::NameserversConfiguration => "Nameservers.Configuration",
+            PropertyKind::Timeservers => "Timeservers",
+            PropertyKind::TimeserversConfiguration => "Timeservers.Configuration",
+            PropertyKind::Domains => "Domains",
+            PropertyKind::DomainsConfiguration => "Domains.Configuration",
+            PropertyKind::Ipv4 => "IPv4",
+            PropertyKind::Ipv4Configuration => "IPv4.Configuration",
+            PropertyKind::Ipv6 => "IPv6",
+            PropertyKind::Ipv6Configuration => "IPv6.Configuration",
+            PropertyKind::Proxy => "Proxy",
+            PropertyKind::ProxyConfiguration => "Proxy.Configuration",
+            PropertyKind::Provider => "Provider",
+            PropertyKind::Ethernet => "Ethernet",
+            PropertyKind::Mdns => "mDNS",
+            PropertyKind::MdnsConfiguration => "mDNS.Configuration",
+        }
+    }
+}
+
+impl FromStr for PropertyKind {
+    type Err = ApiError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "State" => Ok(PropertyKind::State),
+            "Error" => Ok(PropertyKind::Error),
+            "Name" => Ok(PropertyKind::Name),
+            "Type" => Ok(PropertyKind::Type),
+            "Security" => Ok(PropertyKind::Security),
+            "Strength" => Ok(PropertyKind::Strength),
+            "Favorite" => Ok(PropertyKind::Favorite),
+            "Immutable" => Ok(PropertyKind::Immutable),
+            "AutoConnect" => Ok(PropertyKind::AutoConnect),
+            "Roaming" => Ok(PropertyKind::Roaming),
+            "Nameservers" => Ok(PropertyKind::Nameservers),
+            "Nameservers.Configuration" => Ok(PropertyKind::NameserversConfiguration),
+            "Timeservers" => Ok(PropertyKind::Timeservers),
+            "Timeservers.Configuration" => Ok(PropertyKind::TimeserversConfiguration),
+            "Domains" => Ok(PropertyKind::Domains),
+            "Domains.Configuration" => Ok(PropertyKind::DomainsConfiguration),
+            "IPv4" => Ok(PropertyKind::Ipv4),
+            "IPv4.Configuration" => Ok(PropertyKind::Ipv4Configuration),
+            "IPv6" => Ok(PropertyKind::Ipv6),
+            "IPv6.Configuration" => Ok(PropertyKind::Ipv6Configuration),
+            "Proxy" => Ok(PropertyKind::Proxy),
+            "Proxy.Configuration" => Ok(PropertyKind::ProxyConfiguration),
+            "Provider" => Ok(PropertyKind::Provider),
+            "Ethernet" => Ok(PropertyKind::Ethernet),
+            "mDNS" => Ok(PropertyKind::Mdns),
+            "mDNS.Configuration" => Ok(PropertyKind::MdnsConfiguration),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string())).into()),
+        }
+    }
+}
+
+/// Service connection state, `from_str` maps the values given over d-bus by
+/// connman.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum State {
+    Idle,
+    Failure,
+    Association,
+    Configuration,
+    Ready,
+    Disconnect,
+    Online,
+}
+
+impl FromStr for State {
+    type Err = ApiError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "idle" => Ok(State::Idle),
+            "failure" => Ok(State::Failure),
+            "association" => Ok(State::Association),
+            "configuration" => Ok(State::Configuration),
+            "ready" => Ok(State::Ready),
+            "disconnect" => Ok(State::Disconnect),
+            "online" => Ok(State::Online),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string())).into()),
+        }
+    }
+}
+
+/// Service error reason.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    OutOfRange,
+    PinMissing,
+    DhcpFailed,
+    ConnectFailed,
+    LoginFailed,
+    AuthFailed,
+    InvalidKey,
+}
+
+impl FromStr for Error {
+    type Err = ApiError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "out-of-range" => Ok(Error::OutOfRange),
+            "pin-missing" => Ok(Error::PinMissing),
+            "dhcp-failed" => Ok(Error::DhcpFailed),
+            "connect-failed" => Ok(Error::ConnectFailed),
+            "login-failed" => Ok(Error::LoginFailed),
+            "auth-failed" => Ok(Error::AuthFailed),
+            "invalid-key" => Ok(Error::InvalidKey),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string())).into()),
+        }
+    }
+}
+
+/// Service type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Type {
+    Wifi,
+    Ethernet,
+    Unknown(String),
+}
+
+impl FromStr for Type {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "wifi" => Ok(Type::Wifi),
+            "ethernet" => Ok(Type::Ethernet),
+            _ => Ok(Type::Unknown(s.to_string())),
+        }
+    }
+}
+
+/// Ipv4 structure
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Ipv4 {
+    pub method: Option<Ipv4Method>,
+    pub address: Option<String>,
+    pub netmask: Option<String>,
+    pub gateway: Option<String>,
+}
+
+pub enum Ipv4Kind {
+    Method,
+    Address,
+    Netmask,
+    Gateway,
+}
+
+impl FromStr for Ipv4Kind {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Method" => Ok(Ipv4Kind::Method),
+            "Address" => Ok(Ipv4Kind::Address),
+            "Netmask" => Ok(Ipv4Kind::Netmask),
+            "Gateway" => Ok(Ipv4Kind::Gateway),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+impl From<Ipv4Kind> for &'static str {
+    fn from(prop: Ipv4Kind) -> Self {
+        match prop {
+            Ipv4Kind::Method => "Method",
+            Ipv4Kind::Address => "Address",
+            Ipv4Kind::Netmask => "Netmask",
+            Ipv4Kind::Gateway => "Gateway",
+        }
+    }
+}
+
+/// Ipv4 method type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Ipv4Method {
+    Dhcp,
+    Manual,
+    Auto,
+    Off,
+    Fixed,
+}
+
+impl FromStr for Ipv4Method {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "dhcp" => Ok(Ipv4Method::Dhcp),
+            "manual" => Ok(Ipv4Method::Manual),
+            "auto" => Ok(Ipv4Method::Auto),
+            "off" => Ok(Ipv4Method::Off),
+            "fixed" => Ok(Ipv4Method::Fixed),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+/// Ipv6 structure
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Ipv6 {
+    pub method: Option<Ipv6Method>,
+    pub address: Option<String>,
+    pub prefix_length: Option<u8>,
+    pub gateway: Option<String>,
+    pub privacy: Option<Ipv6Privacy>,
+}
+
+pub enum Ipv6Kind {
+    Method,
+    Address,
+    PrefixLength,
+    Gateway,
+    Privacy,
+}
+
+impl FromStr for Ipv6Kind {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Method" => Ok(Ipv6Kind::Method),
+            "Address" => Ok(Ipv6Kind::Address),
+            "PrefixLength" => Ok(Ipv6Kind::PrefixLength),
+            "Gateway" => Ok(Ipv6Kind::Gateway),
+            "Privacy" => Ok(Ipv6Kind::Privacy),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+impl From<Ipv6Kind> for &'static str {
+    fn from(prop: Ipv6Kind) -> Self {
+        match prop {
+            Ipv6Kind::Method => "Method",
+            Ipv6Kind::Address => "Address",
+            Ipv6Kind::PrefixLength => "PrefixLength",
+            Ipv6Kind::Gateway => "Gateway",
+            Ipv6Kind::Privacy => "Privacy",
+        }
+    }
+}
+
+/// Ipv6 method type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Ipv6Method {
+    Auto,
+    Manual,
+    SixToFour,
+    Off,
+}
+
+impl FromStr for Ipv6Method {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(Ipv6Method::Auto),
+            "manual" => Ok(Ipv6Method::Manual),
+            "6to4" => Ok(Ipv6Method::SixToFour),
+            "off" => Ok(Ipv6Method::Off),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+/// Ipv6 privacy type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Ipv6Privacy {
+    Disabled,
+    Enabled,
+    // The spelling used by connman
+    Prefered,
+}
+
+impl FromStr for Ipv6Privacy {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "disabled" => Ok(Ipv6Privacy::Disabled),
+            "enabled" => Ok(Ipv6Privacy::Enabled),
+            // The spelling used by connman
+            "prefered" => Ok(Ipv6Privacy::Prefered),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+/// Proxy structure
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Proxy {
+    pub method: Option<ProxyMethod>,
+    pub url: Option<String>,
+    pub servers: Option<Vec<String>>,
+    pub excludes: Option<Vec<String>>,
+}
+
+pub enum ProxyKind {
+    Method,
+    Url,
+    Servers,
+    Excludes,
+}
+
+impl FromStr for ProxyKind {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Method" => Ok(ProxyKind::Method),
+            "Url" => Ok(ProxyKind::Url),
+            "Servers" => Ok(ProxyKind::Servers),
+            "Excludes" => Ok(ProxyKind::Excludes),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+impl From<ProxyKind> for &'static str {
+    fn from(prop: ProxyKind) -> Self {
+        match prop {
+            ProxyKind::Method => "Method",
+            ProxyKind::Url => "Url",
+            ProxyKind::Servers => "Servers",
+            ProxyKind::Excludes => "Excludes",
+        }
+    }
+}
+
+/// Proxy method type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProxyMethod {
+    Direct,
+    Auto,
+    Manual,
+}
+
+impl FromStr for ProxyMethod {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "direct" => Ok(ProxyMethod::Direct),
+            "auto" => Ok(ProxyMethod::Auto),
+            "manual" => Ok(ProxyMethod::Manual),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+impl From<ProxyMethod> for &'static str {
+    fn from(method: ProxyMethod) -> Self {
+        match method {
+            ProxyMethod::Direct => "direct",
+            ProxyMethod::Auto => "auto",
+            ProxyMethod::Manual => "manual",
+        }
+    }
+}
+
+/// Provider structure
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Provider {
+    pub host: Option<String>,
+    pub domain: Option<String>,
+    pub name: Option<String>,
+    pub type_: Option<String>,
+}
+
+pub enum ProviderKind {
+    Host,
+    Domain,
+    Name,
+    Type,
+}
+
+impl FromStr for ProviderKind {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Host" => Ok(ProviderKind::Host),
+            "Domain" => Ok(ProviderKind::Domain),
+            "Name" => Ok(ProviderKind::Name),
+            "Type" => Ok(ProviderKind::Type),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+impl From<ProviderKind> for &'static str {
+    fn from(prop: ProviderKind) -> Self {
+        match prop {
+            ProviderKind::Host => "Host",
+            ProviderKind::Domain => "Domain",
+            ProviderKind::Name => "Name",
+            ProviderKind::Type => "Type",
+        }
+    }
+}
+
+/// Provider structure
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Ethernet {
+    pub method: Option<EthernetMethod>,
+    pub interface: Option<String>,
+    pub address: Option<String>,
+    pub mtu: Option<u16>,
+    // Deprecated:
+    //pub speed: u16,
+    //pub duplex: String
+}
+
+pub enum EthernetKind {
+    Method,
+    Interface,
+    Address,
+    Mtu,
+}
+
+impl FromStr for EthernetKind {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Method" => Ok(EthernetKind::Method),
+            "Interface" => Ok(EthernetKind::Interface),
+            "Address" => Ok(EthernetKind::Address),
+            "MTU" => Ok(EthernetKind::Mtu),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+impl From<EthernetKind> for &'static str {
+    fn from(prop: EthernetKind) -> Self {
+        match prop {
+            EthernetKind::Method => "Method",
+            EthernetKind::Interface => "Interface",
+            EthernetKind::Address => "Address",
+            EthernetKind::Mtu => "MTU",
+        }
+    }
+}
+
+/// Proxy method type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EthernetMethod {
+    Auto,
+    Manual,
+}
+
+impl FromStr for EthernetMethod {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "auto" => Ok(EthernetMethod::Auto),
+            "manual" => Ok(EthernetMethod::Manual),
+            _ => Err(PropertyError::Cast(Cow::Owned(s.to_string()))),
+        }
+    }
+}
+
+impl From<EthernetMethod> for &'static str {
+    fn from(method: EthernetMethod) -> Self {
+        match method {
+            EthernetMethod::Auto => "auto",
+            EthernetMethod::Manual => "manual",
+        }
     }
 }

--- a/src/api/technology.rs
+++ b/src/api/technology.rs
@@ -6,17 +6,20 @@ use std::rc::Rc;
 use std::collections::HashMap;
 
 use super::gen::technology::Technology as ITechnology;
-use super::{Error, RefArgMap};
+use super::{Error as ApiError, RefArgMap};
+use std::str::FromStr;
+use std::borrow::Cow;
+use std::convert::TryFrom;
+use crate::api::{PropertyError, FromProperties};
 
 #[cfg(feature = "introspection")]
 use xml::reader::EventReader;
 
 /// Futures-aware wrapper struct for connman Technology object.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Technology {
-    connection: Rc<AConnection>,
-    pub path: dbus::Path<'static>,
-    pub args: RefArgMap,
+    connpath: ConnPath<'static, Rc<AConnection>>,
+    pub props: Properties,
 }
 
 impl Technology {
@@ -24,43 +27,194 @@ impl Technology {
         connection: Rc<AConnection>,
         path: dbus::Path<'static>,
         args: RefArgMap,
-    ) -> Self {
-        Technology {
-            connection,
-            path,
-            args,
-        }
+    ) -> Result<Self, ApiError> {
+        Properties::try_from(args)
+            .map_err(ApiError::from)
+            .map(|props| {
+                Technology {
+                    connpath: Self::connpath(path, connection),
+                    props,
+                }
+            })
     }
 
-    pub fn connpath(&self, conn: Rc<AConnection>) -> ConnPath<'static, Rc<AConnection>> {
+    pub fn connpath(path: dbus::Path<'static>, conn: Rc<AConnection>) -> ConnPath<'static, Rc<AConnection>> {
         let connpath = ConnPath {
             conn: conn,
             dest: "net.connman".into(),
-            path: self.path.clone(),
+            path,
             timeout: 5000,
         };
         connpath
+    }
+
+    pub fn path(&self) -> &dbus::Path<'static> {
+        &self.connpath.path
     }
 }
 
 impl Technology {
     #[cfg(feature = "introspection")]
-    pub fn introspect(&self) -> impl Future<Item=EventReader<std::io::Cursor<Vec<u8>>>, Error=Error> {
+    pub fn introspect(&self) -> impl Future<Item=EventReader<std::io::Cursor<Vec<u8>>>, Error=ApiError> {
         use crate::api::gen::technology::OrgFreedesktopDBusIntrospectable as Introspectable;
 
-        Introspectable::introspect(&self.connpath(self.connection.clone()))
-            .map_err(|e| e.into())
+        Introspectable::introspect(&self.connpath)
+            .map_err(ApiError::from)
             .map(|s| {
                 let rdr = std::io::Cursor::new(s.into_bytes());
                 EventReader::new(rdr)
             })
     }
 
-    pub fn scan(&self) -> impl Future<Item=(), Error=Error> {
-        let connclone = self.connection.clone();
+    pub fn scan(&self) -> impl Future<Item=(), Error=ApiError> {
+        ITechnology::scan(&self.connpath)
+            .map_err(ApiError::from)
+    }
+}
 
-        let connpath = self.connpath(connclone);
-        ITechnology::scan(&connpath)
+impl Technology {
+    pub fn set_powered(&self, powered: bool) -> impl Future<Item=(), Error=ApiError> {
+        ITechnology::set_property(&self.connpath, PropertyKind::Powered.into(), arg::Variant(powered))
             .map_err(|e| e.into())
+    }
+
+    pub fn get_powered(&self) -> impl Future<Item=bool, Error=ApiError> {
+        ITechnology::get_properties(&self.connpath)
+            .map_err(ApiError::from)
+            .and_then(move |a|
+                super::get_property::<bool>(&a, PropertyKind::Powered.into())
+                    .map_err(ApiError::from)
+            )
+    }
+
+    pub fn get_connected(&self) -> impl Future<Item=bool, Error=ApiError> {
+        ITechnology::get_properties(&self.connpath)
+            .map_err(ApiError::from)
+            .and_then(move |a|
+                super::get_property::<bool>(&a, PropertyKind::Connected.into())
+                    .map_err(ApiError::from)
+            )
+    }
+
+    pub fn get_name(&self) -> impl Future<Item=String, Error=ApiError> {
+        ITechnology::get_properties(&self.connpath)
+            .map_err(ApiError::from)
+            .and_then(move |a|
+                super::get_property_fromstr::<String>(&a, PropertyKind::Name.into())
+                    .map_err(ApiError::from)
+            )
+    }
+
+    pub fn get_type(&self) -> impl Future<Item=Type, Error=ApiError> {
+        ITechnology::get_properties(&self.connpath)
+            .map_err(ApiError::from)
+            .and_then(move |a|
+                super::get_property_fromstr::<Type>(&a, PropertyKind::Type.into())
+                    .map_err(ApiError::from)
+            )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Properties {
+    pub powered: bool,
+    pub connected: bool,
+    pub name: String,
+    pub type_: Type,
+    pub tethering: bool,
+    pub tethering_identifier: Option<String>,
+    pub tethering_passphrase: Option<String>,
+}
+
+impl FromProperties for Type {
+    fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
+        super::get_property_fromstr::<Self>(properties, prop_name)
+    }
+}
+
+impl Properties {
+    pub fn try_from(props: RefArgMap) -> Result<Self, PropertyError> {
+        let powered = bool::from_properties(&props, PropertyKind::Powered.into())?;
+        let connected = bool::from_properties(&props, PropertyKind::Connected.into())?;
+        let name = String::from_properties(&props, PropertyKind::Name.into())?;
+        let type_ = Type::from_properties(&props, PropertyKind::Type.into())?;
+        let tethering = bool::from_properties(&props, PropertyKind::Connected.into())?;
+
+        let tethering_identifier: Option<String> = FromProperties::from_properties(
+            &props,
+            PropertyKind::TetheringIdentifier.into()
+        )?;
+        let tethering_passphrase: Option<String> = FromProperties::from_properties(
+            &props,
+            PropertyKind::TetheringPassphrase.into()
+        )?;
+
+        Ok(Properties {
+            powered,
+            connected,
+            name,
+            type_,
+            tethering,
+            tethering_identifier,
+            tethering_passphrase,
+        })
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum PropertyKind {
+    Powered,
+    Connected,
+    Name,
+    Type,
+    Tethering,
+    TetheringIdentifier,
+    TetheringPassphrase,
+}
+
+impl From<PropertyKind> for &'static str {
+    fn from(prop: PropertyKind) -> Self {
+        match prop {
+            PropertyKind::Powered => "Powered",
+            PropertyKind::Connected => "Connected",
+            PropertyKind::Name => "Name",
+            PropertyKind::Type => "Type",
+            PropertyKind::Tethering => "Tethering",
+            PropertyKind::TetheringIdentifier => "TetheringIdentifier",
+            PropertyKind::TetheringPassphrase => "TetheringPassphrase",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Type {
+    Ethernet,
+    Wifi,
+    P2p,
+    Unknown(String),
+}
+
+impl From<Type> for Cow<'static, str> {
+    fn from(ty: Type) -> Self {
+        match ty {
+            Type::Ethernet => Cow::Borrowed("ethernet"),
+            Type::Wifi => Cow::Borrowed("wifi"),
+            Type::P2p => Cow::Borrowed("p2p"),
+            Type::Unknown(inner) => Cow::Owned(inner),
+        }
+    }
+}
+
+impl FromStr for Type {
+    type Err = PropertyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let t = match s {
+            "ethernet" => Type::Ethernet,
+            "wifi" => Type::Wifi,
+            "p2p" => Type::P2p,
+            _ => Type::Unknown(s.to_string())
+        };
+        Ok(t)
     }
 }


### PR DESCRIPTION
To further the goal of abstracting away anything D-Bus, this change introduces the `FromProperties` trait which all property fields contained in the `RefArgMap` for Service/Technology must implement to compose a typed `Property` struct (which `service` and `technology` both separately define).

The `Property` struct gets composed at initialization, and for now returns a `PropertyError` for issues like casting. It also may throw `NotAvailable` if a prop marked mandatory (not wrapped in `Option`) wasn't found in the map, but that would likely be due to an incorrect interpretation in code about which fields are actually mandatory and which are optional. E.g., Technology field `Type` should never be missing, so the field doesn't get wrapped in `Option`.

The manual parsing and composition was tedious, but should serve as a base for future improvements, such as potentially deriving serde's `Deserialize`, or some other custom derivable trait.