### PR TITLE
service: make properties public

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,7 @@ script:
   - sudo target/debug/examples/wifi_introspect
   - sudo target/debug/examples/wifi_scan_list
 
+cache:
+  cargo: true
+  directories:
+    - connman

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Changed
+- Make Service properties public
+
 ## [0.1.2] - 2019-09-04
 
 ### Added

--- a/ci/connman.sh
+++ b/ci/connman.sh
@@ -3,6 +3,7 @@
 set -x
 
 CONNMAN_SRC_PATH="./connman"
+CONNMAND_PATH="src/connmand"
 
 do_action_prep() {
     sudo apt install \
@@ -22,14 +23,18 @@ do_action_prep() {
 
     git clone --depth 1 -b 1.36 \
         https://git.kernel.org/pub/scm/network/connman/connman.git \
-        ${CONNMAN_SRC_PATH}
+        ${CONNMAN_SRC_PATH} || echo "connman repo already exists"
 }
 
 do_action_build() {
     cd ${CONNMAN_SRC_PATH}
-    ./bootstrap
-    ./configure
-    make
+
+    # only build if daemon doesn't already exist (from cache)
+    if [ ! -f "${CONNMAND_PATH}" ]; then
+        ./bootstrap
+        ./configure
+        make
+    fi
     sudo make install
     cd ..
 

--- a/ci/hostapd.sh
+++ b/ci/hostapd.sh
@@ -12,7 +12,7 @@ do_action_build() {
     cd ${HOSTAP_SRC_PATH}/hostapd
     cp defconfig .config
     make clean
-    make
+    make -j3
     sudo make install
     cd ../..
 }

--- a/ci/wpa_supplicant.sh
+++ b/ci/wpa_supplicant.sh
@@ -13,7 +13,7 @@ do_action_prep() {
 
     git clone --depth 1 -b hostap_2_7 \
         git://w1.fi/hostap.git \
-        ${HOSTAP_SRC_PATH}
+        ${HOSTAP_SRC_PATH} || echo "hostap/supplicant repo already exists"
 }
 
 do_action_build() {
@@ -26,7 +26,7 @@ CONFIG_CTRL_IFACE_DBUS_NEW=y
 CONFIG_CTRL_IFACE_DBUS_INTRO=y
 EOF
 
-    make
+    make -j3
     sudo make install
     cd ../..
 }

--- a/src/api/gen/manager.rs
+++ b/src/api/gen/manager.rs
@@ -12,13 +12,13 @@ use std::rc::Rc;
 
 pub trait OrgFreedesktopDBusIntrospectable {
     type Err;
-    fn introspect(&self) -> Box<Future<Item=String, Error=Self::Err>>;
+    fn introspect(&self) -> Box<dyn Future<Item=String, Error=Self::Err>>;
 }
 
 impl<'a> OrgFreedesktopDBusIntrospectable for dbus::ConnPath<'a, Rc<AConnection>> {
     type Err = DbusError;
 
-    fn introspect(&self) -> Box<Future<Item=String, Error=Self::Err>> {
+    fn introspect(&self) -> Box<dyn Future<Item=String, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"org.freedesktop.DBus.Introspectable".into(), &"Introspect".into());
         let introspect_fut = self.conn
             .method_call(msg)
@@ -51,29 +51,29 @@ impl<'a> OrgFreedesktopDBusIntrospectable for dbus::ConnPath<'a, Rc<AConnection>
 
 pub trait Manager {
     type Err;
-    fn get_properties(&self) -> Box<Future<Item=::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Error=Self::Err>>;
-    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn get_technologies(&self) -> Box<Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)>, Error=Self::Err>>;
-    fn remove_provider(&self, provider: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn get_services(&self) -> Box<Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)>, Error=Self::Err>>;
-    fn get_peers(&self) -> Box<Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)>, Error=Self::Err>>;
-    fn connect_provider(&self, provider: ::std::collections::HashMap<&str, arg::Variant<Box<arg::RefArg>>>) -> Box<Future<Item=dbus::Path<'static>, Error=Self::Err>>;
-    fn register_agent(&self, path: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn unregister_agent(&self, path: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn register_counter(&self, path: dbus::Path, accuracy: u32, period: u32) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn unregister_counter(&self, path: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn create_session(&self, settings: ::std::collections::HashMap<&str, arg::Variant<Box<arg::RefArg>>>, notifier: dbus::Path) -> Box<Future<Item=dbus::Path<'static>, Error=Self::Err>>;
-    fn destroy_session(&self, session: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn request_private_network(&self) -> Box<Future<Item=(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, dbus::OwnedFd), Error=Self::Err>>;
-    fn release_private_network(&self, path: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn register_peer_service(&self, specification: ::std::collections::HashMap<&str, arg::Variant<Box<arg::RefArg>>>, master: bool) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn unregister_peer_service(&self, specification: ::std::collections::HashMap<&str, arg::Variant<Box<arg::RefArg>>>) -> Box<Future<Item=(), Error=Self::Err>>;
+    fn get_properties(&self) -> Box<dyn Future<Item=::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, Error=Self::Err>>;
+    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn get_technologies(&self) -> Box<dyn Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)>, Error=Self::Err>>;
+    fn remove_provider(&self, provider: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn get_services(&self) -> Box<dyn Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)>, Error=Self::Err>>;
+    fn get_peers(&self) -> Box<dyn Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)>, Error=Self::Err>>;
+    fn connect_provider(&self, provider: ::std::collections::HashMap<&str, arg::Variant<Box<dyn arg::RefArg>>>) -> Box<dyn Future<Item=dbus::Path<'static>, Error=Self::Err>>;
+    fn register_agent(&self, path: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn unregister_agent(&self, path: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn register_counter(&self, path: dbus::Path, accuracy: u32, period: u32) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn unregister_counter(&self, path: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn create_session(&self, settings: ::std::collections::HashMap<&str, arg::Variant<Box<dyn arg::RefArg>>>, notifier: dbus::Path) -> Box<dyn Future<Item=dbus::Path<'static>, Error=Self::Err>>;
+    fn destroy_session(&self, session: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn request_private_network(&self) -> Box<dyn Future<Item=(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, dbus::OwnedFd), Error=Self::Err>>;
+    fn release_private_network(&self, path: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn register_peer_service(&self, specification: ::std::collections::HashMap<&str, arg::Variant<Box<dyn arg::RefArg>>>, master: bool) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn unregister_peer_service(&self, specification: ::std::collections::HashMap<&str, arg::Variant<Box<dyn arg::RefArg>>>) -> Box<dyn Future<Item=(), Error=Self::Err>>;
 }
 
 impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
     type Err = DbusError;
 
-    fn get_properties(&self) -> Box<Future<Item=::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Error=Self::Err>> {
+    fn get_properties(&self) -> Box<dyn Future<Item=::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"GetProperties".into());
         let get_properties_fut = self.conn
             .method_call(msg)
@@ -90,7 +90,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
                         }
                     }).and_then(|_m| {
                         let mut i = _m.iter_init();
-                        let properties: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>> =
+                        let properties: ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>> =
                         match i.read() {
                             Err(_e) => {
                                 return Err(DbusError::new_custom("org.freedesktop.DBus.Failed", "type mismatch"));
@@ -103,7 +103,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(get_properties_fut)
     }
 
-    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"SetProperty".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -130,7 +130,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(set_property_fut)
     }
 
-    fn get_technologies(&self) -> Box<Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)>, Error=Self::Err>> {
+    fn get_technologies(&self) -> Box<dyn Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)>, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"GetTechnologies".into());
         let get_technologies_fut = self.conn
             .method_call(msg)
@@ -147,7 +147,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
                         }
                     }).and_then(|_m| {
                         let mut i = _m.iter_init();
-                        let technologies: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)> =
+                        let technologies: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)> =
                         match i.read() {
                             Err(_e) => {
                                 return Err(DbusError::new_custom("org.freedesktop.DBus.Failed", "type mismatch"));
@@ -160,7 +160,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(get_technologies_fut)
     }
 
-    fn remove_provider(&self, provider: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn remove_provider(&self, provider: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"RemoveProvider".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -186,7 +186,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(remove_provider_fut)
     }
 
-    fn get_services(&self) -> Box<Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)>, Error=Self::Err>> {
+    fn get_services(&self) -> Box<dyn Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)>, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"GetServices".into());
         let get_services_fut = self.conn
             .method_call(msg)
@@ -203,7 +203,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
                         }
                     }).and_then(|_m| {
                         let mut i = _m.iter_init();
-                        let services: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)> =
+                        let services: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)> =
                         match i.read() {
                             Err(_e) => {
                                 return Err(DbusError::new_custom("org.freedesktop.DBus.Failed", "type mismatch"));
@@ -216,7 +216,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(get_services_fut)
     }
 
-    fn get_peers(&self) -> Box<Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)>, Error=Self::Err>> {
+    fn get_peers(&self) -> Box<dyn Future<Item=Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)>, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"GetPeers".into());
         let get_peers_fut = self.conn
             .method_call(msg)
@@ -233,7 +233,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
                         }
                     }).and_then(|_m| {
                         let mut i = _m.iter_init();
-                        let peers: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)> =
+                        let peers: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)> =
                         match i.read() {
                             Err(_e) => {
                                 return Err(DbusError::new_custom("org.freedesktop.DBus.Failed", "type mismatch"));
@@ -246,7 +246,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(get_peers_fut)
     }
 
-    fn connect_provider(&self, provider: ::std::collections::HashMap<&str, arg::Variant<Box<arg::RefArg>>>) -> Box<Future<Item=dbus::Path<'static>, Error=Self::Err>> {
+    fn connect_provider(&self, provider: ::std::collections::HashMap<&str, arg::Variant<Box<dyn arg::RefArg>>>) -> Box<dyn Future<Item=dbus::Path<'static>, Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"ConnectProvider".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -280,7 +280,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(connect_provider_fut)
     }
 
-    fn register_agent(&self, path: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn register_agent(&self, path: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"RegisterAgent".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -306,7 +306,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(register_agent_fut)
     }
 
-    fn unregister_agent(&self, path: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn unregister_agent(&self, path: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"UnregisterAgent".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -332,7 +332,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(unregister_agent_fut)
     }
 
-    fn register_counter(&self, path: dbus::Path, accuracy: u32, period: u32) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn register_counter(&self, path: dbus::Path, accuracy: u32, period: u32) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"RegisterCounter".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -360,7 +360,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(register_counter_fut)
     }
 
-    fn unregister_counter(&self, path: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn unregister_counter(&self, path: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"UnregisterCounter".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -386,7 +386,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(unregister_counter_fut)
     }
 
-    fn create_session(&self, settings: ::std::collections::HashMap<&str, arg::Variant<Box<arg::RefArg>>>, notifier: dbus::Path) -> Box<Future<Item=dbus::Path<'static>, Error=Self::Err>> {
+    fn create_session(&self, settings: ::std::collections::HashMap<&str, arg::Variant<Box<dyn arg::RefArg>>>, notifier: dbus::Path) -> Box<dyn Future<Item=dbus::Path<'static>, Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"CreateSession".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -421,7 +421,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(create_session_fut)
     }
 
-    fn destroy_session(&self, session: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn destroy_session(&self, session: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"DestroySession".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -447,7 +447,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(destroy_session_fut)
     }
 
-    fn request_private_network(&self) -> Box<Future<Item=(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, dbus::OwnedFd), Error=Self::Err>> {
+    fn request_private_network(&self) -> Box<dyn Future<Item=(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, dbus::OwnedFd), Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"RequestPrivateNetwork".into());
         let request_private_network_fut = self.conn
             .method_call(msg)
@@ -471,7 +471,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
                             },
                             Ok(o) => o
                         };
-                        let settings: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>> =
+                        let settings: ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>> =
                         match i.read() {
                             Err(_e) => {
                                 return Err(DbusError::new_custom("org.freedesktop.DBus.Failed", "type mismatch"));
@@ -491,7 +491,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(request_private_network_fut)
     }
 
-    fn release_private_network(&self, path: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn release_private_network(&self, path: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"ReleasePrivateNetwork".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -517,7 +517,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(release_private_network_fut)
     }
 
-    fn register_peer_service(&self, specification: ::std::collections::HashMap<&str, arg::Variant<Box<arg::RefArg>>>, master: bool) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn register_peer_service(&self, specification: ::std::collections::HashMap<&str, arg::Variant<Box<dyn arg::RefArg>>>, master: bool) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"RegisterPeerService".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -544,7 +544,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(register_peer_service_fut)
     }
 
-    fn unregister_peer_service(&self, specification: ::std::collections::HashMap<&str, arg::Variant<Box<arg::RefArg>>>) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn unregister_peer_service(&self, specification: ::std::collections::HashMap<&str, arg::Variant<Box<dyn arg::RefArg>>>) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Manager".into(), &"UnregisterPeerService".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -574,7 +574,7 @@ impl<'a> Manager for dbus::ConnPath<'a, Rc<AConnection>> {
 #[derive(Debug, Default)]
 pub struct ManagerPropertyChanged {
     pub name: String,
-    pub value: arg::Variant<Box<arg::RefArg + 'static>>,
+    pub value: arg::Variant<Box<dyn arg::RefArg + 'static>>,
 }
 
 impl dbus::SignalArgs for ManagerPropertyChanged {
@@ -594,7 +594,7 @@ impl dbus::SignalArgs for ManagerPropertyChanged {
 #[derive(Debug, Default)]
 pub struct ManagerTechnologyAdded {
     pub path: dbus::Path<'static>,
-    pub properties: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>,
+    pub properties: ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>,
 }
 
 impl dbus::SignalArgs for ManagerTechnologyAdded {
@@ -630,7 +630,7 @@ impl dbus::SignalArgs for ManagerTechnologyRemoved {
 
 #[derive(Debug, Default)]
 pub struct ManagerServicesChanged {
-    pub changed: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)>,
+    pub changed: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)>,
     pub removed: Vec<dbus::Path<'static>>,
 }
 
@@ -650,7 +650,7 @@ impl dbus::SignalArgs for ManagerServicesChanged {
 
 #[derive(Debug, Default)]
 pub struct ManagerPeersChanged {
-    pub changed: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>)>,
+    pub changed: Vec<(dbus::Path<'static>, ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>)>,
     pub removed: Vec<dbus::Path<'static>>,
 }
 
@@ -670,14 +670,14 @@ impl dbus::SignalArgs for ManagerPeersChanged {
 
 pub trait Clock {
     type Err;
-    fn get_properties(&self) -> Box<Future<Item=::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Error=Self::Err>>;
-    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<Future<Item=(), Error=Self::Err>>;
+    fn get_properties(&self) -> Box<dyn Future<Item=::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, Error=Self::Err>>;
+    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<dyn Future<Item=(), Error=Self::Err>>;
 }
 
 impl<'a> Clock for dbus::ConnPath<'a, Rc<AConnection>> {
     type Err = DbusError;
 
-    fn get_properties(&self) -> Box<Future<Item=::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Error=Self::Err>> {
+    fn get_properties(&self) -> Box<dyn Future<Item=::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Clock".into(), &"GetProperties".into());
         let get_properties_fut = self.conn
             .method_call(msg)
@@ -694,7 +694,7 @@ impl<'a> Clock for dbus::ConnPath<'a, Rc<AConnection>> {
                         }
                     }).and_then(|_m| {
                         let mut i = _m.iter_init();
-                        let properties: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>> =
+                        let properties: ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>> =
                         match i.read() {
                             Err(_e) => {
                                 return Err(DbusError::new_custom("org.freedesktop.DBus.Failed", "type mismatch"));
@@ -707,7 +707,7 @@ impl<'a> Clock for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(get_properties_fut)
     }
 
-    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Clock".into(), &"SetProperty".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -738,7 +738,7 @@ impl<'a> Clock for dbus::ConnPath<'a, Rc<AConnection>> {
 #[derive(Debug, Default)]
 pub struct ClockPropertyChanged {
     pub name: String,
-    pub value: arg::Variant<Box<arg::RefArg + 'static>>,
+    pub value: arg::Variant<Box<dyn arg::RefArg + 'static>>,
 }
 
 impl dbus::SignalArgs for ClockPropertyChanged {

--- a/src/api/gen/service.rs
+++ b/src/api/gen/service.rs
@@ -12,13 +12,13 @@ use std::rc::Rc;
 
 pub trait OrgFreedesktopDBusIntrospectable {
     type Err;
-    fn introspect(&self) -> Box<Future<Item=String, Error=Self::Err>>;
+    fn introspect(&self) -> Box<dyn Future<Item=String, Error=Self::Err>>;
 }
 
 impl<'a> OrgFreedesktopDBusIntrospectable for dbus::ConnPath<'a, Rc<AConnection>> {
     type Err = DbusError;
 
-    fn introspect(&self) -> Box<Future<Item=String, Error=Self::Err>> {
+    fn introspect(&self) -> Box<dyn Future<Item=String, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"org.freedesktop.DBus.Introspectable".into(), &"Introspect".into());
         let introspect_fut = self.conn
             .method_call(msg)
@@ -51,21 +51,21 @@ impl<'a> OrgFreedesktopDBusIntrospectable for dbus::ConnPath<'a, Rc<AConnection>
 
 pub trait Service {
     type Err;
-    fn get_properties(&self) -> Box<Future<Item=::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Error=Self::Err>>;
-    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn clear_property(&self, name: &str) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn connect(&self) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn disconnect(&self) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn remove(&self) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn move_before(&self, service: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn move_after(&self, service: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn reset_counters(&self) -> Box<Future<Item=(), Error=Self::Err>>;
+    fn get_properties(&self) -> Box<dyn Future<Item=::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, Error=Self::Err>>;
+    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn clear_property(&self, name: &str) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn connect(&self) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn disconnect(&self) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn remove(&self) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn move_before(&self, service: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn move_after(&self, service: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn reset_counters(&self) -> Box<dyn Future<Item=(), Error=Self::Err>>;
 }
 
 impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
     type Err = DbusError;
 
-    fn get_properties(&self) -> Box<Future<Item=::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Error=Self::Err>> {
+    fn get_properties(&self) -> Box<dyn Future<Item=::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Service".into(), &"GetProperties".into());
         let get_properties_fut = self.conn
             .method_call(msg)
@@ -82,7 +82,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
                         }
                     }).and_then(|_m| {
                         let mut i = _m.iter_init();
-                        let properties: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>> =
+                        let properties: ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>> =
                         match i.read() {
                             Err(_e) => {
                                 return Err(DbusError::new_custom("org.freedesktop.DBus.Failed", "type mismatch"));
@@ -95,7 +95,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(get_properties_fut)
     }
 
-    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Service".into(), &"SetProperty".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -122,7 +122,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(set_property_fut)
     }
 
-    fn clear_property(&self, name: &str) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn clear_property(&self, name: &str) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Service".into(), &"ClearProperty".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -148,7 +148,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(clear_property_fut)
     }
 
-    fn connect(&self) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn connect(&self) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Service".into(), &"Connect".into());
         let connect_fut = self.conn
             .method_call(msg)
@@ -170,7 +170,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(connect_fut)
     }
 
-    fn disconnect(&self) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn disconnect(&self) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Service".into(), &"Disconnect".into());
         let disconnect_fut = self.conn
             .method_call(msg)
@@ -192,7 +192,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(disconnect_fut)
     }
 
-    fn remove(&self) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn remove(&self) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Service".into(), &"Remove".into());
         let remove_fut = self.conn
             .method_call(msg)
@@ -214,7 +214,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(remove_fut)
     }
 
-    fn move_before(&self, service: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn move_before(&self, service: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Service".into(), &"MoveBefore".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -240,7 +240,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(move_before_fut)
     }
 
-    fn move_after(&self, service: dbus::Path) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn move_after(&self, service: dbus::Path) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Service".into(), &"MoveAfter".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -266,7 +266,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(move_after_fut)
     }
 
-    fn reset_counters(&self) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn reset_counters(&self) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Service".into(), &"ResetCounters".into());
         let reset_counters_fut = self.conn
             .method_call(msg)
@@ -292,7 +292,7 @@ impl<'a> Service for dbus::ConnPath<'a, Rc<AConnection>> {
 #[derive(Debug, Default)]
 pub struct ServicePropertyChanged {
     pub name: String,
-    pub value: arg::Variant<Box<arg::RefArg + 'static>>,
+    pub value: arg::Variant<Box<dyn arg::RefArg + 'static>>,
 }
 
 impl dbus::SignalArgs for ServicePropertyChanged {

--- a/src/api/gen/technology.rs
+++ b/src/api/gen/technology.rs
@@ -12,13 +12,13 @@ use std::rc::Rc;
 
 pub trait OrgFreedesktopDBusIntrospectable {
     type Err;
-    fn introspect(&self) -> Box<Future<Item=String, Error=Self::Err>>;
+    fn introspect(&self) -> Box<dyn Future<Item=String, Error=Self::Err>>;
 }
 
 impl<'a> OrgFreedesktopDBusIntrospectable for dbus::ConnPath<'a, Rc<AConnection>> {
     type Err = DbusError;
 
-    fn introspect(&self) -> Box<Future<Item=String, Error=Self::Err>> {
+    fn introspect(&self) -> Box<dyn Future<Item=String, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"org.freedesktop.DBus.Introspectable".into(), &"Introspect".into());
         let introspect_fut = self.conn
             .method_call(msg)
@@ -51,15 +51,15 @@ impl<'a> OrgFreedesktopDBusIntrospectable for dbus::ConnPath<'a, Rc<AConnection>
 
 pub trait Technology {
     type Err;
-    fn get_properties(&self) -> Box<Future<Item=::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Error=Self::Err>>;
-    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<Future<Item=(), Error=Self::Err>>;
-    fn scan(&self) -> Box<Future<Item=(), Error=Self::Err>>;
+    fn get_properties(&self) -> Box<dyn Future<Item=::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, Error=Self::Err>>;
+    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<dyn Future<Item=(), Error=Self::Err>>;
+    fn scan(&self) -> Box<dyn Future<Item=(), Error=Self::Err>>;
 }
 
 impl<'a> Technology for dbus::ConnPath<'a, Rc<AConnection>> {
     type Err = DbusError;
 
-    fn get_properties(&self) -> Box<Future<Item=::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>>, Error=Self::Err>> {
+    fn get_properties(&self) -> Box<dyn Future<Item=::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>>, Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Technology".into(), &"GetProperties".into());
         let get_properties_fut = self.conn
             .method_call(msg)
@@ -76,7 +76,7 @@ impl<'a> Technology for dbus::ConnPath<'a, Rc<AConnection>> {
                         }
                     }).and_then(|_m| {
                         let mut i = _m.iter_init();
-                        let properties: ::std::collections::HashMap<String, arg::Variant<Box<arg::RefArg + 'static>>> =
+                        let properties: ::std::collections::HashMap<String, arg::Variant<Box<dyn arg::RefArg + 'static>>> =
                         match i.read() {
                             Err(_e) => {
                                 return Err(DbusError::new_custom("org.freedesktop.DBus.Failed", "type mismatch"));
@@ -89,7 +89,7 @@ impl<'a> Technology for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(get_properties_fut)
     }
 
-    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn set_property<I1: arg::Arg + arg::Append>(&self, name: &str, value: arg::Variant<I1>) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let mut msg = Message::method_call(&self.dest, &self.path, &"net.connman.Technology".into(), &"SetProperty".into());
         {
             let mut i = arg::IterAppend::new(&mut msg);
@@ -116,7 +116,7 @@ impl<'a> Technology for dbus::ConnPath<'a, Rc<AConnection>> {
         Box::new(set_property_fut)
     }
 
-    fn scan(&self) -> Box<Future<Item=(), Error=Self::Err>> {
+    fn scan(&self) -> Box<dyn Future<Item=(), Error=Self::Err>> {
         let msg = Message::method_call(&self.dest, &self.path, &"net.connman.Technology".into(), &"Scan".into());
         let scan_fut = self.conn
             .method_call(msg)
@@ -142,7 +142,7 @@ impl<'a> Technology for dbus::ConnPath<'a, Rc<AConnection>> {
 #[derive(Debug, Default)]
 pub struct TechnologyPropertyChanged {
     pub name: String,
-    pub value: arg::Variant<Box<arg::RefArg + 'static>>,
+    pub value: arg::Variant<Box<dyn arg::RefArg + 'static>>,
 }
 
 impl dbus::SignalArgs for TechnologyPropertyChanged {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -14,9 +14,9 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::str::FromStr;
 
-type RefArgMap = HashMap<String, Variant<Box<RefArg + 'static>>>;
-type RefArgMapRef<'a> = HashMap<String, &'a RefArg>;
-type RefArgIter<'a> = Box<Iterator<Item=&'a RefArg> + 'a>;
+type RefArgMap = HashMap<String, Variant<Box<dyn RefArg + 'static>>>;
+type RefArgMapRef<'a> = HashMap<String, &'a dyn RefArg>;
+type RefArgIter<'a> = Box<dyn Iterator<Item=&'a dyn RefArg> + 'a>;
 
 #[derive(Debug, Fail)]
 pub enum Error {

--- a/src/api/service.rs
+++ b/src/api/service.rs
@@ -221,7 +221,7 @@ impl FromProperties for Ipv6 {
 impl FromProperties for Proxy {
     fn from_properties(properties: &RefArgMap, prop_name: &'static str) -> Result<Self, PropertyError> {
         let mut i = get_property_argiter(properties, prop_name)?;
-        let mut m: HashMap<&str, &RefArg> = HashMap::new();
+        let mut m: HashMap<&str, &dyn RefArg> = HashMap::new();
         while let Some(key) = i.next().and_then(|k| k.as_str()) {
             if let Some(val) = i.next() {
                 let _ = m.insert(key, val);

--- a/src/api/service.rs
+++ b/src/api/service.rs
@@ -20,7 +20,7 @@ use dbus::arg::{Variant, RefArg, cast};
 #[derive(Debug)]
 pub struct Service {
     connpath: ConnPath<'static, Rc<AConnection>>,
-    properties: Properties,
+    pub props: Properties,
 }
 
 impl Service {
@@ -34,7 +34,7 @@ impl Service {
 
         Ok(Service {
             connpath: Self::connpath(path, connection),
-            properties,
+            props: properties,
         })
     }
 
@@ -90,58 +90,58 @@ impl Service {
 #[derive(Debug)]
 pub struct Properties {
     /// Connection state
-    state: State,
+    pub state: State,
     /// Error reason; only valid for `State::Failure`
-    error: Option<Error>,
+    pub error: Option<Error>,
     /// Service name
-    name: Option<String>,
+    pub name: Option<String>,
     /// Service name
-    type_: Option<Type>,
+    pub type_: Option<Type>,
     /// Service name
     // TODO: enum variants?
-    security: Option<Vec<String>>,
+    pub security: Option<Vec<String>>,
     /// Signal strength
-    strength: Option<u8>,
+    pub strength: Option<u8>,
     /// Set if favorite or User-selected
-    favorite: bool,
+    pub favorite: bool,
     /// Set if configured externally
-    immutable: bool,
+    pub immutable: bool,
     /// Whether or not to automatically connect if no other connection
-    autoconnect: bool,
+    pub autoconnect: bool,
     /// Set if service is roaming
-    roaming: Option<bool>,
+    pub roaming: Option<bool>,
     /// List of currently-active nameservers
-    nameservers: Vec<String>, // TODO: Deserialize `String` into `IpAddr`?
+    pub nameservers: Vec<String>, // TODO: Deserialize `String` into `IpAddr`?
     /// List of manually-configured nameservers
-    nameservers_config: Vec<String>, // TODO: Deserialize `String` into `IpAddr`?
+    pub nameservers_config: Vec<String>, // TODO: Deserialize `String` into `IpAddr`?
     /// List of currently-active timeservers
-    timeservers: Vec<String>,
+    pub timeservers: Vec<String>,
     /// List of manually-configured timeservers
-    timeservers_config: Vec<String>,
+    pub timeservers_config: Vec<String>,
     /// List of currently-used search domains
-    domains: Vec<String>,
+    pub domains: Vec<String>,
     /// List of manually-configured search domains
-    domains_config: Vec<String>,
+    pub domains_config: Vec<String>,
     /// Ipv4 related information
-    ipv4: Ipv4,
+    pub ipv4: Ipv4,
     /// Ipv4 config related information
-    ipv4_config: Ipv4,
+    pub ipv4_config: Ipv4,
     /// Ipv6 related information
-    ipv6: Ipv6,
+    pub ipv6: Ipv6,
     /// Ipv6 config related information
-    ipv6_config: Ipv6,
+    pub ipv6_config: Ipv6,
     /// Proxy related information
-    proxy: Proxy,
+    pub proxy: Proxy,
     /// Proxy config related information
-    proxy_config: Proxy,
+    pub proxy_config: Proxy,
     /// Provider (VPN) related information
-    provider: Provider,
+    pub provider: Provider,
     /// Ethernet related information
-    ethernet: Ethernet,
+    pub ethernet: Ethernet,
     /// Whether or not mDNS support is enabled
-    mdns: Option<bool>,
+    pub mdns: Option<bool>,
     /// Whether or not mDNS (config) support is enabled
-    mdns_config: Option<bool>,
+    pub mdns_config: Option<bool>,
 }
 
 impl FromProperties for State {


### PR DESCRIPTION
An oversight from the #7, but service properties are now public.

Also apply `cargo-fix` resolve warnings from stable rustc, and get a start on caching for cargo and `connmand` build artifacts to speed up CI.