### PR TITLE
Replace failure with thiserror.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ introspection = ["xml-rs"]
 [dependencies]
 dbus = "0.6"
 dbus-tokio = "0.3"
-failure = "0.1"
+thiserror = "1.0.11"
 futures = "0.1"
 tokio = "0.1"
 xml-rs = { version = "0.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,6 @@
 
 extern crate dbus;
 extern crate dbus_tokio;
-#[macro_use]
-extern crate failure;
 extern crate futures;
 extern crate tokio;
 


### PR DESCRIPTION
More modern error crate that integrates with the new `std::err::Error` trait (important for crates that are using `Box<dyn std::error::Error>` or `anyhow::Error` etc.) as well as providing a simpler derive interface.