### PR TITLE
Feat/update libs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,13 @@ default = []
 introspection = ["xml-rs"]
 
 [dependencies]
-dbus = { git = "https://github.com/diwic/dbus-rs" }
-dbus-tokio = { git = "https://github.com/diwic/dbus-rs" }
+dbus = { version = "0.9", features = ["futures"]}
+dbus-tokio = { version = "0.7" }
 thiserror = "1.0.11"
-tokio = "0.2.13"
+tokio = "1.21.2"
 xml-rs = { version = "0.3", optional = true }
 
 [dev-dependencies]
+tokio = { version = "1.21.2", features = ["full"] }
 hex = "0.3"
 structopt = "0.2"

--- a/examples/wifi_connect.rs
+++ b/examples/wifi_connect.rs
@@ -118,13 +118,7 @@ async fn main() {
     let maybe_svc = services.iter().find(|svc| {
         //wifi_ffffffffffff_00112233aabbccdd_managed_psk
         //tech_mac.addr...._hex.ssid........_security...
-        let pathv = svc
-            .path()
-            .as_cstr()
-            .to_str()
-            .unwrap()
-            .split("_")
-            .collect::<Vec<&str>>();
+        let pathv = svc.path().split("_").collect::<Vec<&str>>();
         let svc_hex_ssid = *pathv.get(2).unwrap();
         let found = svc_hex_ssid == hex_ssid;
         if found {

--- a/src/api/manager.rs
+++ b/src/api/manager.rs
@@ -50,12 +50,18 @@ impl<T: NonblockReply, C: Deref<Target = T> + Clone> Manager<C> {
     pub async fn get_services(&self) -> Result<Vec<Service<C>>, Error> {
         let connclone = self.proxy.connection.clone();
 
-        let v = IManager::get_services(&self.proxy).await?;
-        Ok(v.into_iter()
+        let services = IManager::get_services(&self.proxy).await?;
+        Ok(services
+            .into_iter()
             .filter_map(|(path, args)| {
                 Service::new(connclone.clone(), path, args, self.timeout).ok()
             })
             .collect())
+    }
+
+    pub async fn register_agent(&self, path: dbus::Path<'static>) -> Result<(), Error> {
+        IManager::register_agent(&self.proxy, path).await?;
+        Ok(())
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -48,11 +48,11 @@ fn get_property<T: Clone + 'static>(
 ) -> Result<T, PropertyError> {
     properties
         .get(prop_name)
-        .ok_or_else(|| PropertyError::NotPresent(Cow::Borrowed(prop_name)))
+        .ok_or(PropertyError::NotPresent(Cow::Borrowed(prop_name)))
         .and_then(|variant| {
             cast::<T>(&variant.0)
                 .cloned()
-                .ok_or_else(|| PropertyError::Cast(Cow::Borrowed(prop_name)))
+                .ok_or(PropertyError::Cast(Cow::Borrowed(prop_name)))
         })
 }
 
@@ -63,12 +63,12 @@ fn get_property_fromstr<T: FromStr + 'static>(
 ) -> Result<T, PropertyError> {
     properties
         .get(prop_name)
-        .ok_or_else(|| PropertyError::NotPresent(Cow::Borrowed(prop_name)))
+        .ok_or(PropertyError::NotPresent(Cow::Borrowed(prop_name)))
         .and_then(|variant| {
             variant
                 .as_str()
                 .and_then(|s| T::from_str(s).ok())
-                .ok_or_else(|| PropertyError::Cast(Cow::Borrowed(prop_name)))
+                .ok_or(PropertyError::Cast(Cow::Borrowed(prop_name)))
         })
 }
 
@@ -79,12 +79,12 @@ fn get_property_argiter<'a>(
 ) -> Result<RefArgIter<'a>, PropertyError> {
     properties
         .get(prop_name)
-        .ok_or_else(|| PropertyError::NotPresent(Cow::Borrowed(prop_name)))
+        .ok_or(PropertyError::NotPresent(Cow::Borrowed(prop_name)))
         .and_then(|variant| {
             variant
                 .0
                 .as_iter()
-                .ok_or_else(|| PropertyError::Cast(Cow::Borrowed(prop_name)))
+                .ok_or(PropertyError::Cast(Cow::Borrowed(prop_name)))
         })
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,10 @@
 #[rustfmt::skip]
 mod gen;
 
+pub use gen::manager::ManagerServicesChanged;
+pub use gen::service::ServicePropertyChanged;
+pub use gen::technology::TechnologyPropertyChanged;
+
 pub mod manager;
 pub mod service;
 pub mod technology;

--- a/src/api/technology.rs
+++ b/src/api/technology.rs
@@ -171,7 +171,7 @@ impl From<PropertyKind> for &'static str {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Type {
     Ethernet,
     Wifi,


### PR DESCRIPTION
This PR updates the crates and fixing clippy warnings.
The part with the
```
pub use gen::manager::ManagerServicesChanged;
pub use gen::service::ServicePropertyChanged;
pub use gen::technology::TechnologyPropertyChanged;
```
is mainly a way to implement property updates on my side. But I'm not sure what API would be nice to expose it. Maybe it's ok if we expose  the generated types? Maybe as `gen` module?